### PR TITLE
Calendar.prototype.addAttendes

### DIFF
--- a/solution_00_bis.js
+++ b/solution_00_bis.js
@@ -6,7 +6,8 @@ function Calendar() {
 }
 
 Calendar.prototype.addAttendes = function(attendes) {
-    this.attendes = clone(attendes);
+    attendes = attendes.filter( (attende) => !this.attendes.find( (a) => a.name === attende.name ) );
+    Array.prototype.push.apply(this.attendes, clone(attendes));
 };
 
 Calendar.prototype.addEvent = function(event) {

--- a/solution_01.js
+++ b/solution_01.js
@@ -25,10 +25,11 @@ Calendar.prototype.protocol = function(attende) {
 };
 
 Calendar.prototype.addAttendes = function(attendes) {
-    this.attendes = attendes.map( (a) => {
+    attendes = attendes.filter( (attende) => !this.attendes.find( (a) => a.name === attende.name ) ).map( (a) => {
         a.__proto__ = this.protocol(a);
         return a;
     });
+    Array.prototype.push.apply(this.attendes, clone(attendes));
 };
 
 Calendar.prototype.addEvent = function(event) {

--- a/test/solution_00_bis.js
+++ b/test/solution_00_bis.js
@@ -25,6 +25,36 @@ describe("solution_00", () => {
         }]);
     });
 
+    describe("calendar", () => {
+        it("should allow adding attendes in batches", () => {
+            calendar.addAttendes([{
+                name: "Thomas",
+                type: 0
+            }, {
+                name: "laptop",
+                type: 1
+            }]);
+
+            chai.expect(
+                calendar.attendes
+            ).to.have.lengthOf(7);
+        });
+
+        it("should ensure attendes are not added multiple times", () => {
+            calendar.addAttendes([{
+                name: "Gabriel",
+                type: 0
+            }, {
+                name: "projector",
+                type: 1
+            }]);
+
+            chai.expect(
+                calendar.attendes
+            ).to.have.lengthOf(5);
+        });
+    });
+
     describe("person", () => {
         it("should be busy during an event", () => {
             calendar.addEvent({

--- a/test/solution_01_bis.js
+++ b/test/solution_01_bis.js
@@ -27,6 +27,36 @@ describe("solution_01", () => {
         ]);
     });
 
+    describe("calendar", () => {
+        it("should allow adding attendes in batches", () => {
+            calendar.addAttendes([{
+                name: "Thomas",
+                type: 0
+            }, {
+                name: "laptop",
+                type: 1
+            }]);
+
+            chai.expect(
+                calendar.attendes
+            ).to.have.lengthOf(7);
+        });
+
+        it("should ensure attendes are not added multiple times", () => {
+            calendar.addAttendes([{
+                name: "Gabriel",
+                type: 0
+            }, {
+                name: "projector",
+                type: 1
+            }]);
+
+            chai.expect(
+                calendar.attendes
+            ).to.have.lengthOf(5);
+        });
+    });
+
     describe("person", () => {
         it("should be busy during an event", () => {
             calendar.addEvent({


### PR DESCRIPTION
Calendar.prototype.addAttendes will now extend the attendee collection upon successive calls, ensuring attendees stay unique in the process.
